### PR TITLE
crypto playnice fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ endif()
 message( STATUS "Using ${CRYPTO} for crypto")
 
 if( CRYPTO STREQUAL openssl )
-  target_sources( secvarctl PRIVATE external/skiboot/libstb/secvar/crypto/crypto-openssl.c )
   target_compile_definitions( secvarctl PRIVATE SECVAR_CRYPTO_OPENSSL )
   find_package( OpenSSL REQUIRED )
   target_link_libraries( secvarctl OpenSSL::SSL )

--- a/Makefile
+++ b/Makefile
@@ -39,20 +39,17 @@ EXTERNAL_SRCS =
 ifeq ($(CRYPTO), openssl)
   _LDFLAGS += -lcrypto
   _CFLAGS += -DSECVAR_CRYPTO_OPENSSL
-  EXTERNAL_SRCS += external/libstb-secvar/src/crypto_openssl.c
 endif
 
 ifeq ($(CRYPTO), gnutls)
   _LDFLAGS += -lgnutls
   _CFLAGS += -DSECVAR_CRYPTO_GNUTLS
-  # TODO port this to live and compile on libstb-secvar
   EXTERNAL_SRCS += external/skiboot/libstb/secvar/crypto/crypto-gnutls.c
 endif
 
 ifeq ($(CRYPTO), mbedtls)
   _LDFLAGS += -lmbedtls -lmbedx509 -lmbedcrypto
   _CFLAGS += -DSECVAR_CRYPTO_MBEDTLS
-  # TODO port this to live and compile on libstb-secvar
   INCLUDES += -I./external/extraMbedtls/include/
   EXTERNAL_SRCS += external/extraMbedtls/pkcs7.c \
                    external/extraMbedtls/pkcs7_write.c \

--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -276,18 +276,16 @@ int create_presigned_hash(const uint8_t *esl, const size_t esl_size,
 
 	rc = crypto_md_generate_hash(prehash, prehash_size, CRYPTO_MD_SHA256, out_buffer,
 				     out_buffer_size);
-	
+
 	if (prehash != NULL)
 		free(prehash);
 
 	if (rc != CRYPTO_SUCCESS) {
 		prlog(PR_ERR, "failed to generate hash\n");
-	}
-	else if (*out_buffer_size != 32) {
+	} else if (*out_buffer_size != 32) {
 		prlog(PR_ERR, "error: size of sha256 is not 32 bytes, found %zu bytes\n",
 		      *out_buffer_size);
-	}
-	else
+	} else
 		return SUCCESS;
 
 	return HASH_FAIL;
@@ -322,15 +320,14 @@ int create_pkcs7(const uint8_t *new_data, const size_t new_data_size,
 	/* get pkcs7 and size, if we are already given ths signatures then call appropriate funcion */
 	if (args->pkcs7_gen_method) {
 		prlog(PR_INFO, "generating pkcs7 with already signed data\n");
-		rc = crypto_pkcs7_generate_w_already_signed_data(out_buffer, out_buffer_size,
-								actual_data, total_size,
-							    args->sign_certs, args->sign_keys,
-							    args->sign_key_count, CRYPTO_MD_SHA256);
+		rc = crypto_pkcs7_generate_w_already_signed_data(
+			out_buffer, out_buffer_size, actual_data, total_size, args->sign_certs,
+			args->sign_keys, args->sign_key_count, CRYPTO_MD_SHA256);
 	} else
-		rc = crypto_pkcs7_generate_w_signature(out_buffer, out_buffer_size,
-							 actual_data, total_size,
-						     args->sign_certs, args->sign_keys,
-						     args->sign_key_count, CRYPTO_MD_SHA256);
+		rc = crypto_pkcs7_generate_w_signature(out_buffer, out_buffer_size, actual_data,
+						       total_size, args->sign_certs,
+						       args->sign_keys, args->sign_key_count,
+						       CRYPTO_MD_SHA256);
 
 	if (actual_data)
 		free(actual_data);
@@ -436,7 +433,7 @@ int is_x509certificate(const uint8_t *buffer, const size_t buffer_size, uint8_t 
 		prlog(PR_WARNING, "WARNING: could not convert PEM to DER, %d\n", rc);
 		return CERT_FAIL;
 	}
-	
+
 	rc = validate_cert(cert, cert_size);
 
 	*cert_data = cert;

--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -100,9 +100,7 @@ int print_cert_info(crypto_x509_t *x509)
 
 	bytes_out = crypto_x509_get_long_desc(x509_info, CERT_BUFFER_SIZE, "\t\t", x509);
 	if (bytes_out <= 0) {
-		prlog(PR_ERR,
-		      "\tERROR: failed to get cert info,rc = %d\n",
-		      bytes_out);
+		prlog(PR_ERR, "\tERROR: failed to get cert info,rc = %d\n", bytes_out);
 		return CERT_FAIL;
 	}
 

--- a/backends/guest/common/util.c
+++ b/backends/guest/common/util.c
@@ -103,7 +103,7 @@ int get_hash_function(const char *name, enum signature_type *returnfunct)
 	prlog(PR_ERR, "error: invalid hash algorithm %s , hint: use -h { ", name);
 
 	for (int i = ST_HASHES_START; i <= ST_HASHES_END; i++) {
-		if (i == ST_HASHES_END )
+		if (i == ST_HASHES_END)
 			prlog(PR_ERR, "%s }\n", signature_type_list[i].name);
 		else
 			prlog(PR_ERR, "%s, ", signature_type_list[i].name);
@@ -132,7 +132,7 @@ int get_x509_hash_function(const char *name, enum signature_type *returnfunct)
 	prlog(PR_ERR, "error: invalid hash algorithm %s , hint: use -h { ", name);
 
 	for (int i = ST_X509_HASHES_START; i <= ST_X509_HASHES_END; i++) {
-		if (i == ST_X509_HASHES_END )
+		if (i == ST_X509_HASHES_END)
 			prlog(PR_ERR, "%s }\n", signature_type_list[i].name);
 		else
 			prlog(PR_ERR, "%s, ", signature_type_list[i].name);

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -84,10 +84,9 @@ int validate_time(timestamp_t *time)
  */
 bool validate_hash(uuid_t type, size_t size)
 {
-
 	int idx = get_signature_type(type);
-	if (idx < ST_HASHES_END || idx < ST_X509_HASHES_START
-		|| signature_type_list[idx].size != size)
+	if (idx < ST_HASHES_END || idx < ST_X509_HASHES_START ||
+	    signature_type_list[idx].size != size)
 		return false;
 
 	return true;

--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -70,8 +70,7 @@ static int generate_esl(const uint8_t *buffer, size_t buffer_size, struct genera
 			break;
 		}
 
-		rc = get_hash_data(buffer, buffer_size, hash_funct, hash_data,
-				   &hash_data_size);
+		rc = get_hash_data(buffer, buffer_size, hash_funct, hash_data, &hash_data_size);
 		if (rc != SUCCESS) {
 			prlog(PR_ERR, "ERROR: failed to generate hash from file\n");
 			break;

--- a/backends/guest/include/common/util.h
+++ b/backends/guest/include/common/util.h
@@ -50,9 +50,9 @@ enum signature_type {
 struct signature_type_info {
 	const char *name;
 	const uuid_t *uuid;
-    /* the following are only used by ST_HASHES_START -> ST_HASHES_END */
-    int crypto_id;
-    size_t size;
+	/* the following are only used by ST_HASHES_START -> ST_HASHES_END */
+	int crypto_id;
+	size_t size;
 };
 
 extern const struct signature_type_info signature_type_list[];
@@ -179,36 +179,36 @@ static inline const char *get_signature_type_string(const uuid_t uuid)
 /* Get crypto lib defined ID for MD alg idx of signature_type_list */
 static inline int get_crypto_alg_id(enum signature_type idx)
 {
-    if (idx > ST_HASHES_END || idx < ST_X509_HASHES_START) {
-        prlog(PR_ERR, "error: invalid crypto alg key %d\n", idx);
-        idx = ST_HASH_SHA256;
-    }
-    return signature_type_list[idx].crypto_id;
+	if (idx > ST_HASHES_END || idx < ST_X509_HASHES_START) {
+		prlog(PR_ERR, "error: invalid crypto alg key %d\n", idx);
+		idx = ST_HASH_SHA256;
+	}
+	return signature_type_list[idx].crypto_id;
 }
 
 /* Get crypto lib defined ID for MD alg idx of signature_type_list */
 static inline size_t get_crypto_alg_len(enum signature_type idx)
 {
-    if (idx > ST_HASHES_END || idx < ST_X509_HASHES_START) {
-        prlog(PR_ERR, "error: invalid crypto alg key %d\n", idx);
-        idx = ST_HASH_SHA256;
-    }
-    return signature_type_list[idx].size;
+	if (idx > ST_HASHES_END || idx < ST_X509_HASHES_START) {
+		prlog(PR_ERR, "error: invalid crypto alg key %d\n", idx);
+		idx = ST_HASH_SHA256;
+	}
+	return signature_type_list[idx].size;
 }
 
 /* Get crypto lib defined ID for MD alg idx of signature_type_list */
-static inline const char * get_crypto_alg_name(enum signature_type idx)
+static inline const char *get_crypto_alg_name(enum signature_type idx)
 {
-    if (idx > ST_HASHES_END || idx < ST_X509_HASHES_START) {
-        prlog(PR_ERR, "error: invalid crypto alg key %d\n", idx);
-        idx = ST_HASH_SHA256;
-    }
-    return signature_type_list[idx].name;
+	if (idx > ST_HASHES_END || idx < ST_X509_HASHES_START) {
+		prlog(PR_ERR, "error: invalid crypto alg key %d\n", idx);
+		idx = ST_HASH_SHA256;
+	}
+	return signature_type_list[idx].name;
 }
 
 /* Get guid from idx of signature_type_list */
 static inline const uuid_t *get_uuid(enum signature_type idx)
 {
-    return signature_type_list[idx].uuid;
+	return signature_type_list[idx].uuid;
 }
 #endif

--- a/backends/host/host_svc_validate.c
+++ b/backends/host/host_svc_validate.c
@@ -484,7 +484,7 @@ out:
  */
 static int validateCertStruct(crypto_x509_t *x509, const char *varName)
 {
-	int rc, len, version;
+	int len, version;
 	// check raw cert data has data
 	len = crypto_x509_get_der_len(x509);
 	if (len < 0) {
@@ -547,8 +547,7 @@ static int validateCertStruct(crypto_x509_t *x509, const char *varName)
 
 	// This part is to print out certificate info
 	if (verbose >= PR_INFO) {
-		rc = printCertInfo(x509);
-		if (rc) {
+		if (printCertInfo(x509)) {
 			return CERT_FAIL;
 		}
 	}

--- a/backends/host/host_svc_validate.c
+++ b/backends/host/host_svc_validate.c
@@ -514,8 +514,7 @@ static int validateCertStruct(crypto_x509_t *x509, const char *varName)
 	}
 	// if public key type is not RSA, then quit (example failures: DSA, ECDSA, RSA_PCC)
 	if (!crypto_x509_is_RSA(x509)) {
-		prlog(PR_ERR,
-		      "ERROR: public key type not supported, expected RSA\n");
+		prlog(PR_ERR, "ERROR: public key type not supported, expected RSA\n");
 		return CERT_FAIL;
 	}
 


### PR DESCRIPTION
Set of fixes for https://github.com/open-power/secvarctl/pull/51 , feel free to either merge this, re-implement, squash, whatever.

Changes:
 - build system tweaks to remove directly referencing `crypto-openssl.c` (built into library)
 - fix formatting (monolith commit, perhaps could be split/rebased/squashed)
 - update libstb-secvar since crypto rewrite was merged
 - remove a variable cppcheck didn't like
 
 There is one additional issue I noted in a comment on the original PR here: https://github.com/open-power/secvarctl/pull/51/files/3f33595e6eb183a70dea1027a405fcb36c1474e3#r1309015588 , I have an additional diff I can apply to this branch to fix that issue as well.
